### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Build the Docker image
         run: docker build . -t docker.pkg.github.com/antoine-gannat/deadline-manager/deadline-manager:latest
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: antoine-gannat/deadline-manager/deadline-manager:latest
           username: ${{ secrets.docker_username }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore